### PR TITLE
gitlab-ci.yml.jj2: List docker images after build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ build:image:
   stage: build
   script:
     - docker build -t "$CURRENT_IMAGE_NAME" .
+    - docker images
     - docker push "$CURRENT_IMAGE_NAME"
 
 lint:

--- a/.moban.dt/gitlab-ci.yml.jj2
+++ b/.moban.dt/gitlab-ci.yml.jj2
@@ -27,6 +27,7 @@ build:image:
   stage: build
   script:
     - docker build -t "$CURRENT_IMAGE_NAME" .
+    - docker images
     - docker push "$CURRENT_IMAGE_NAME"
 
 {% if is_lint_image %}
@@ -42,6 +43,7 @@ lint:
   stage: build
   image: $CI_REGISTRY/django-mobans/lint-image
   before_script: []
+{# 'coala --ci' is default for the image, however script: is required #}
   script: coala --ci
 {% endif %}
 

--- a/.moban.dt/travis.yml.jj2
+++ b/.moban.dt/travis.yml.jj2
@@ -3,9 +3,7 @@
 {% else %}
 {%   set is_lint_image = False %}
 {% endif %}
-{% if is_lint_image %}
-{%   set lint_image = image.name + ':this' %}
-{% else %}
+{% if not lint_image %}
 {%   set lint_image = 'djangomobans/lint-image' %}
 {% endif %}
 sudo: false
@@ -17,12 +15,18 @@ env:
   global:
     - IMAGE_NAME={{ image.name }}:this
 
-install:
-  - hooks/build
+{# This assumes the lint image already exists, so lint_image should be
+   overriden to bootstrap a new lint repo. #}
+before_script:
+  - docker run -v=$(pwd):/app --workdir=/app {{ lint_image }}
 
 script:
+  - hooks/build
   - docker images
-  - docker run -v=$(pwd):/app --workdir=/app {{ lint_image }}
+{% if is_lint_image %}
+  # Re-run lint using built image
+  - docker run -v=$(pwd):/app --workdir=/app $IMAGE_NAME
+{% endif %}
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ env:
   global:
     - IMAGE_NAME=django-mobans-empty-image:this
 
-install:
-  - hooks/build
+before_script:
+  - docker run -v=$(pwd):/app --workdir=/app djangomobans/lint-image
 
 script:
+  - hooks/build
   - docker images
-  - docker run -v=$(pwd):/app --workdir=/app djangomobans/lint-image
 
 notifications:
   email: false


### PR DESCRIPTION
Also re-arrange travis so build occurs in `script:`
and lint is done before the build.

Closes https://github.com/django-mobans/docker-mobans/issues/5